### PR TITLE
Fix runtime duration (extended)

### DIFF
--- a/.github/workflows/arc-test-sleepy-matrix.yaml
+++ b/.github/workflows/arc-test-sleepy-matrix.yaml
@@ -9,7 +9,7 @@ on:
       delay:
         description: "How long to sleep in seconds"
         required: true
-        default: "20"
+        default: "120"
 
 jobs:
   arc-runner-job:


### PR DESCRIPTION
Increase the default runtime duration to 120 seconds (2 minutes) instead of 20 seconds.